### PR TITLE
messages: add support for bulk adding/removing a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,41 @@ zulip.users.me.pointer.retrieve().then((res) => {
 });
 ```
 
+### Message Flags
+Message flags are used to mark message as read or unread, to star a message, and much more!
+
+#### Valid Message Flags
+The list of possible flags is:
+['read', 'starred', 'mentioned', 'wildcard_mentioned', 'has_alert_word', 'historical']
+
+#### Adding a Flag
+`zulip.messages.flags.add({flag, messages})` can be used to add a flag to a list of messages.
+Its params are `flag`, which is a string from the [list of possible flags](#valid-message-flags),
+and `messages` which is an array of message ids (integers).
+
+```js
+// Mark the first message as read
+const params = {
+  messages: [0],
+  flag: 'read',
+};
+zulip.messages.flags.add(params).then(console.log);
+```
+
+#### Removing a Flag
+`zulip.messages.flags.remove({flag, messages})` can be used to remove a flag from a list of messages.
+Its params are `flag`, which is a string from the [list of possible flags](#valid-message-flags),
+and `messages` which is an array of message ids (integers).
+
+```js
+// Mark the first message as unread
+const params = {
+  messages: [0],
+  flag: 'read',
+};
+zulip.messages.flags.remove(params).then(console.log);
+```
+
 ### Private Messages
 #### Send a Private Message
 Specify `type` to be `private` in the params object passed to `zulip.messages.send()`

--- a/examples/messages.js
+++ b/examples/messages.js
@@ -38,5 +38,15 @@ zulip(config).then((z) => {
       readParams.anchor = resp.pointer;
       z.messages.retrieve(readParams).then(console.log);
     });
+
+    // Mark the last message as unread
+    const flagParams = {
+      messages: [readParams.anchor],
+      flag: 'read',
+    };
+    z.messages(config).flags.remove(flagParams).then(console.log);
+
+    // Mark the last message as read
+    z.messages(config).flags.add(flagParams).then(console.log);
   }).then(res => console.log(res.messages));
 }).catch(err => console.log(err.message));

--- a/src/resources/messages.js
+++ b/src/resources/messages.js
@@ -1,18 +1,38 @@
 const api = require('../api');
 
 function messages(config) {
+  const baseURL = `${config.apiURL}/messages`;
+  const flagsURL = `${baseURL}/flags`;
   return {
     retrieve: (initialParams) => {
-      const url = `${config.apiURL}/messages`;
       const params = initialParams;
       if (params.narrow) {
         params.narrow = JSON.stringify(params.narrow);
       }
-      return api(url, config, 'GET', params);
+      return api(baseURL, config, 'GET', params);
     },
-    send: (params) => {
-      const url = `${config.apiURL}/messages`;
-      return api(url, config, 'POST', params);
+    send: params => api(baseURL, config, 'POST', params),
+    flags: {
+      add: (initialParams) => {
+        // params.flag can be one of 'read', 'starred', 'mentioned',
+        // 'wildcard_mentioned', 'has_alert_word', 'historical',
+        const params = initialParams;
+        params.op = 'add';
+        if (params.messages) {
+          params.messages = JSON.stringify(params.messages);
+        }
+        return api(flagsURL, config, 'POST', params);
+      },
+      remove: (initialParams) => {
+        // params.flag can be one of 'read', 'starred', 'mentioned',
+        // 'wildcard_mentioned', 'has_alert_word', 'historical',
+        const params = initialParams;
+        params.op = 'remove';
+        if (params.messages) {
+          params.messages = JSON.stringify(params.messages);
+        }
+        return api(flagsURL, config, 'POST', params);
+      },
     },
   };
 }

--- a/test/resources/messages.js
+++ b/test/resources/messages.js
@@ -35,4 +35,22 @@ describe('Messages', () => {
     };
     messages(config).retrieve(params).should.eventually.have.property('result', 'success');
   });
+
+  it('Should mark message as read', () => {
+    const params = {
+      flag: 'read',
+      messages: [0],
+    };
+    messages(config).flags.add(params)
+      .should.eventually.have.property('result', 'success');
+  });
+
+  it('Should mark message as unread', () => {
+    const params = {
+      flag: 'read',
+      messages: [0],
+    };
+    messages(config).flags.remove(params)
+      .should.eventually.have.property('result', 'success');
+  });
 });


### PR DESCRIPTION
This is a work in progress to mark messages as read (among other things), thanks to @timabbott's helpful comment on the update pointer PR:

More importantly, this isn't the right endpoint for marking something as read; this is the endpoint for moving the home view (which has a side effect of making some things read).

You want /messages/flags, and I would definitely implement it as the bulk operation, since that's almost always what one wants.

As always, feedback would be super helpful.

One thing that would be great is to have an description for the various flags - I think read/starred are pretty self-explanatory, the others I've listed are
['mentioned', 'wildcard_mentioned', 'has_alert_word', 'historical']. (there may be others that I've missed).